### PR TITLE
update urls

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package>
   <name>rqt_action</name>
   <version>0.4.7</version>
-  <description>rqt_action provides a feature to introspect all available ROS 
+  <description>rqt_action provides a feature to introspect all available ROS
   action (from actionlib) types. By utilizing rqt_msg, the output format is
   unified with it and rqt_srv. Note that the actions shown on this plugin
   is the ones that are stored on your machine, not on the ROS core your rqt
@@ -11,10 +11,9 @@
   <maintainer email="ablasdel@gmail.com">Aaron Blasdel</maintainer>
   <license>BSD</license>
 
-
-  <url type="website">http://ros.org/wiki/rqt_action</url>
-  <url type="repository">https://github.com/ros-visualization/rqt_common_plugins</url>
-  <url type="bugtracker">https://github.com/ros-visualization/rqt_common_plugins/issues</url>
+  <url type="website">http://wiki.ros.org/rqt_action</url>
+  <url type="repository">https://github.com/ros-visualization/rqt_action</url>
+  <url type="bugtracker">https://github.com/ros-visualization/rqt_action/issues</url>
 
   <author>Isaac Isao Saito</author>
 

--- a/package.xml
+++ b/package.xml
@@ -8,6 +8,7 @@
   is the ones that are stored on your machine, not on the ROS core your rqt
   instance connects to.</description>
 
+  <maintainer email="mikael@osrfoundation.org">Mikael Arguedas</maintainer>
   <maintainer email="ablasdel@gmail.com">Aaron Blasdel</maintainer>
   <license>BSD</license>
 


### PR DESCRIPTION
With the plugin being split out from `rqt_common_plugins` I will do a last release for Lunar (as well as re-release for Kinetic, Jade, and Indigo) in the next days. After that I will stop watching this repo, not look at issues and pull requests, and not perform new releases.

Someone needs to take over the maintenance role which specifically includes doing new releases. @ablasdel You are currently listed in the manifest as the maintainer. I am not sure if you want to take this role and fully take over this repository? @mikaelarguedas Since you maintain `actionlib` maybe you want to be associated with this repo? Or anyone else would like to step up (@cottsay @mrdanbrooks @130s since you have contributed to the package in the past)?

Please let me know if you want to be added / removed from the list of maintainers in the manifest. Otherwise I will go ahead and merge this as-is and release the package a last time setting the maintenance status to `unmaintained`.