### PR TITLE
Porting rqt_action to ROS2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,0 @@
-cmake_minimum_required(VERSION 2.8.3)
-project(rqt_action)
-find_package(catkin REQUIRED)
-catkin_package()
-catkin_python_setup()
-
-install(FILES plugin.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)

--- a/package.xml
+++ b/package.xml
@@ -19,8 +19,6 @@
 
   <author>Isaac Isao Saito</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
-
   <!-- 3/11/2013 (Isaac) run_depend on actionlib will be commented out for now
   until rqt_py_common.rosaction gets moved to actionlib. -->
   <!-- <run_depend>actionlib</run_depend> -->
@@ -29,7 +27,7 @@
   <run_depend>rqt_py_common</run_depend>
 
   <export>
-    <architecture_independent/>
+    <build_type>ament_python</build_type>
     <rqt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,34 @@
-#!/usr/bin/env python
+from setuptools import setup
 
-from distutils.core import setup
-from catkin_pkg.python_setup import generate_distutils_setup
-
-d = generate_distutils_setup(
-    packages=['rqt_action'],
+package_name = 'rqt_action'
+setup(
+    name=package_name,
+    version='0.4.9',
     package_dir={'': 'src'},
+    packages=[package_name],
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+        ('share/' + package_name, ['plugin.xml'])
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    author='Isaac Isao Saito',
+    maintainer='Mikael Arguedas, Aaron Blasdel, Geoffrey Biggs',
+    maintainer_email='mikael@osrfoundation.org',
+    keywords=['ROS'],
+    classifiers=[
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
+        'Topic :: Software Development',
+    ],
+    description=(
+        'rqt_action provides a feature to introspect all available ROS action (from actionlib) '
+        'types. By utilizing rqt_msg, the output format is unified with it and rqt_srv. Note that '
+        'the actions shown on this plugin is the ones that are stored on your machine, not on the '
+        'ROS core your rqt instance connects to.'
+    ),
+    license='BSD',
 )
-
-setup(**d)

--- a/src/rqt_action/action_plugin.py
+++ b/src/rqt_action/action_plugin.py
@@ -33,7 +33,7 @@
 from qt_gui.plugin import Plugin
 
 from rqt_msg.messages_widget import MessagesWidget
-from rqt_py_common import rosaction
+from rqt_py_common.message_helpers import ACTION_MODE
 
 
 class ActionPlugin(Plugin):
@@ -41,7 +41,7 @@ class ActionPlugin(Plugin):
     def __init__(self, context):
         super(ActionPlugin, self).__init__(context)
         self.setObjectName('Action')
-        self._widget = MessagesWidget(rosaction.MODE_ACTION)
+        self._widget = MessagesWidget(ACTION_MODE)
         self._widget.setWindowTitle('Action Type Browser')
         if context.serial_number() > 1:
             self._widget.setWindowTitle(self._widget.windowTitle() +


### PR DESCRIPTION
This ports rqt_action to ROS2. Pretty simple PR as most of the logic adjustment happens in the linked PRs below.

Depends on:
https://github.com/ros2/rosidl_python/pull/21
https://github.com/ros-visualization/rqt/pull/186
https://github.com/ros-visualization/rqt_msg/pull/4