### PR TITLE
Import setup from setuptools instead of distutils.core

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <package>
   <name>rqt_action</name>
   <version>0.4.9</version>

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="3">
   <name>rqt_action</name>
   <version>0.4.9</version>
   <description>rqt_action provides a feature to introspect all available ROS
@@ -21,13 +21,15 @@
   <author>Isaac Isao Saito</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <!-- 3/11/2013 (Isaac) run_depend on actionlib will be commented out for now
   until rqt_py_common.rosaction gets moved to actionlib. -->
   <!-- <run_depend>actionlib</run_depend> -->
-  <run_depend>rospy</run_depend>
-  <run_depend>rqt_msg</run_depend>
-  <run_depend>rqt_py_common</run_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>rqt_msg</exec_depend>
+  <exec_depend>rqt_py_common</exec_depend>
 
   <export>
     <architecture_independent/>

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rqt_action</name>
   <version>0.4.9</version>

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,4 @@
-<package format="3">
+<package>
   <name>rqt_action</name>
   <version>0.4.9</version>
   <description>rqt_action provides a feature to introspect all available ROS

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,8 @@
   <author>Isaac Isao Saito</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <!-- 3/11/2013 (Isaac) run_depend on actionlib will be commented out for now
   until rqt_py_common.rosaction gets moved to actionlib. -->

--- a/package.xml
+++ b/package.xml
@@ -21,8 +21,6 @@
   <author>Isaac Isao Saito</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
-  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <!-- 3/11/2013 (Isaac) run_depend on actionlib will be commented out for now
   until rqt_py_common.rosaction gets moved to actionlib. -->

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,4 @@
 <package format="3">
-<package>
   <name>rqt_action</name>
   <version>0.4.9</version>
   <description>rqt_action provides a feature to introspect all available ROS

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<package format="3">
 <package>
   <name>rqt_action</name>
   <version>0.4.9</version>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
Recently users of newer distributions who build Noetic from source noticed issues when importing setup from distutils.core.
This problem was discussed on [Discourse](https://discourse.ros.org/t/ros-1-and-python-3-10s-deprecation-of-distutils-core/29834), and we hope that we can make the needed updates to Noetic to allow for future builds from source of Noetic.
As a first step, this PR introduces changes from the [Noetic Migration Guide](https://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils) that addresses the change to the setuptools module instead of distutils.core and the corresponding buildtool_depend tags for python 2&3.